### PR TITLE
Remove blank lemmas from greek_lemmatized_sents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# PyCharm
+.idea/


### PR DESCRIPTION
Fixes #3. Blank lemmas removed from 619 token/lemma pairs (out of 549,287 pairs in 33,555 sentences).